### PR TITLE
Narrower hour items

### DIFF
--- a/src/components/DCWeatherIcon.vue
+++ b/src/components/DCWeatherIcon.vue
@@ -47,9 +47,7 @@ if (!WeatherCodeMap.has(props.weather_code)) {
 </script>
 
 <template>
-    <div>
-        <img v-bind:src="'../src/assets/icons/' + weather_obj.name" v-bind:alt="'weather icon:' + weather_obj.alt">
-    </div>
+    <img v-bind:src="'../src/assets/icons/' + weather_obj.name" v-bind:alt="'weather icon:' + weather_obj.alt">
 </template>
 
 <style scoped>

--- a/src/components/DCWindIcon.vue
+++ b/src/components/DCWindIcon.vue
@@ -28,16 +28,12 @@ if (props.wind_speed > 25) {
 </script>
 
 <template>
-  <div class="windArrowDiv">
-    <img :style="{ rotate: wind_direction + 'deg', scale: scale_factor }" :src="imgSrc" :alt="imgAlt">
-  </div>
+  <img :style="{ rotate: wind_direction + 'deg', scale: scale_factor }" :src="imgSrc" :alt="imgAlt">
 </template>
 
 <style scoped>
 img {
   width: 80px;
-}
-.windArrowDiv {
   padding: 2px;
   margin: 5px;
 }

--- a/src/components/HCWeatherIcon.vue
+++ b/src/components/HCWeatherIcon.vue
@@ -57,9 +57,7 @@ if (!WeatherCodeMap.has(props.weather_code)) {
 </script>
 
 <template>
-    <div>
-        <img v-bind:src="'../src/assets/icons/' + weather_obj.name" v-bind:alt="'weather icon:' + weather_obj.alt">
-    </div>
+    <img v-bind:src="'../src/assets/icons/' + weather_obj.name" v-bind:alt="'weather icon:' + weather_obj.alt">
 </template>
 
 <style scoped>

--- a/src/components/HCWindIcon.vue
+++ b/src/components/HCWindIcon.vue
@@ -28,16 +28,12 @@ if (props.wind_speed > 25) {
 </script>
 
 <template>
-  <div class="windArrowDiv">
-    <img :style="{ rotate: wind_direction + 'deg', scale: scale_factor }" :src="imgSrc" :alt="imgAlt">
-  </div>
+  <img :style="{ rotate: wind_direction + 'deg', scale: scale_factor }" :src="imgSrc" :alt="imgAlt">
 </template>
 
 <style scoped>
 img {
   width: 80px;
-}
-.windArrowDiv {
   padding: 2px;
   margin: 5px;
 }

--- a/src/components/HourConteiner.vue
+++ b/src/components/HourConteiner.vue
@@ -24,14 +24,19 @@ var dayORnight = ""
 <template>
     <div  :class="dayORnight" class="OneHourDiv">
         <HCTime :time="hour_obj.time"></HCTime>
-        <HCWeatherIcon :is_Day="hour_obj.is_day" :weather_code="hour_obj.weathercode"></HCWeatherIcon>
+        <HCWeatherIcon class="icons" :is_Day="hour_obj.is_day" :weather_code="hour_obj.weathercode"></HCWeatherIcon>
         <HCTemp :temp="hour_obj.temp"></HCTemp>
         <HCSmallInfo :temp_apparent="hour_obj.temp_app" :precipitation="hour_obj.precipitation" :wind_speed="hour_obj.wind_speed" :wind_direction="hour_obj.wind_dir"></HCSmallInfo>
-        <HCWindIcon :wind_speed="hour_obj.wind_speed" :wind_direction="hour_obj.wind_dir"></HCWindIcon>
+        <HCWindIcon class="icons" :wind_speed="hour_obj.wind_speed" :wind_direction="hour_obj.wind_dir"></HCWindIcon>
     </div>
 </template>
 
 <style scoped>
+
+.icons{
+    width: 50px;
+}
+
 .OneHourDiv{
     align-items: center;
     display: flex;


### PR DESCRIPTION
1. Removed unnecessary div wrappers for the icon components, that way img style can be set directly where every the component is used.
2. Make the icon width smaller for hours, to make them more distinguishable from the day information and to more easily see multiple hours.

![image](https://github.com/Vaaarna/weather2.0/assets/55343748/942fbbde-15e2-4be5-98f1-c47bdbdf0061)
